### PR TITLE
fix resolve path issue for win8

### DIFF
--- a/problems/meet_pipe/setup.js
+++ b/problems/meet_pipe/setup.js
@@ -3,7 +3,7 @@ var path = require('path');
 var aliens = require('./aliens.json');
 
 module.exports = function () {
-    var file = path.relative(__dirname, 'data.txt');
+    var file = path.resolve(__dirname, 'data.txt');
     var data = '';
     
     var data = '';


### PR DESCRIPTION
path.relative results in c:\data.txt when stream-adventure is installed with -g and run from another folder, which errors on win8 with EPERM error unless you are running cmd as admin.

path.resolve will place data.txt in the meet-pipe folder.
