### PR TITLE
make menu colors configurable for weird color schemes

### DIFF
--- a/bin/cmd.js
+++ b/bin/cmd.js
@@ -105,12 +105,25 @@ if (argv._[0] === 'verify' || argv._[0] === 'run') {
     }
 }
 else {
-    var menu = showMenu({ completed: getData('completed') || [] });
-    menu.on('select', onselect);
-    menu.on('exit', function () {
-        console.log();
-        process.exit(0);
-    });
+  var opts = {
+    completed: getData('completed') || []
+  };
+
+  if (argv.b || argv.bg){
+    opts.bg = argv.b || argv.bg;
+  }
+
+  if (argv.f || argv.fg){
+    opts.fg = argv.f || argv.fg;
+  }
+
+  var menu = showMenu(opts);
+
+  menu.on('select', onselect);
+  menu.on('exit', function () {
+      console.log();
+      process.exit(0);
+  });
 }
 
 function onselect (name) {

--- a/bin/menu.js
+++ b/bin/menu.js
@@ -5,7 +5,14 @@ var EventEmitter = require('events').EventEmitter;
 
 module.exports = function (opts) {
     var emitter = new EventEmitter;
-    var menu = tmenu({ width: 65, x: 3, y : 2 });
+
+    var menu = tmenu({
+      width: 65,
+      x: 3, y: 2, 
+      bg: opts.bg || 'blue',
+      fg: opts.fg || 'white'
+    });
+
     menu.reset();
     
     menu.write('STREAMS ADVENTURE\n');


### PR DESCRIPTION
Here's what I see when I load up the stream-adventure:

![screen shot 2013-09-17 at 10 32 28 am](https://f.cloud.github.com/assets/175515/1159150/4d4e7c4a-1fc1-11e3-8666-71ee1a9f63ce.png)

Oh no! Perhaps I have a weird color scheme, but the background isn't working at all for me. I like low-contrast text, which looks good except when it's a background. So, here I've added `--fg` (or `-f` if you prefer) and `--bg` (`-b`) options so you can run `stream-adventure --bg black` and have a readable background, as such:

![screen shot 2013-09-17 at 10 46 12 am](https://f.cloud.github.com/assets/175515/1159157/7bc8fea6-1fc1-11e3-80bf-4bb81601e892.png)

I can apply the same thing to the rest of the schools if you find this useful.
