### PR TITLE
use tmpdir to store datafile so it works on `-g` install

### DIFF
--- a/problems/meet_pipe/setup.js
+++ b/problems/meet_pipe/setup.js
@@ -1,12 +1,12 @@
 var fs = require('fs');
 var path = require('path');
+var os = require('os');
 var aliens = require('./aliens.json');
 
 module.exports = function () {
-    var file = path.resolve(__dirname, 'data.txt');
+    var file = path.resolve(os.tmpdir(), 'meet-pipe-data.txt');
     var data = '';
-    
-    var data = '';
+
     for (var i = 0; i < 10; i++) {
         var alien = aliens[Math.floor(Math.random() * aliens.length)];
         data += alien + '\n';


### PR DESCRIPTION
also delete duplicate data = line
also give data.txt slightly more meaningful, less likely to collide name
