### PR TITLE
Added some advice to failed verify output for debugging help.

### DIFF
--- a/bin/cmd.js
+++ b/bin/cmd.js
@@ -105,7 +105,7 @@ if (argv._[0] === 'verify' || argv._[0] === 'run') {
         console.log('# FAIL');
         console.log(
             "\nYour solution didn't match the expected output."
-            + ' Try again!'
+            + ' Try again, or run `stream-adventure run program.js` to see your solution\'s output.'
         );
     }
 }


### PR DESCRIPTION
This is a lovely little teaching/learning tool, but it took me quite a few failed attempts to verify with syntax errors before I realised I could do `stream-adventure run` as well as `stream-adventure verify` to be able to debug my attempts (I know... RTFM).

Adding a little bit of advice to the failed verification message might just help reduce the frustration levels of people who plough through without reading the help.
