### PR TITLE
Fixed Bug in Websockets Problem

### DIFF
--- a/bin/verify.js
+++ b/bin/verify.js
@@ -21,7 +21,6 @@ COLORS.RESET = '\x1b[00m';
 
 module.exports = function (acmd, bcmd, opts) {
     if (!opts) opts = {};
-    
     var a;
     if (typeof opts.a === 'function') {
         a = opts.a(acmd);
@@ -53,8 +52,13 @@ module.exports = function (acmd, bcmd, opts) {
         b.on('kill', function () { if (b.kill) b.kill() });
     }
     
-    var c = compare(opts.a || a.stdout || a, opts.b || b.stdout || b, opts);
-    
+    if (typeof opts.a === 'function' || typeof opts.b === 'function') {
+        var c = compare(a.stdout || a, b.stdout || b, opts);
+    }
+    else {
+        var c = compare(opts.a || a.stdout || a, opts.b || b.stdout || b, opts);
+    }
+
     if (opts.showStdout) {
         (a.stdout || a).pipe(process.stdout);
         if (a.stderr) a.stderr.pipe(process.stderr);
@@ -84,10 +88,9 @@ function compare (actual, expected, opts) {
     output.queue(COLORS.RESET);
     
     if (!opts.long) {
-        output.queue(wrap('ACTUAL', 30) + '     EXPECTED\n');
-        output.queue(wrap('------', 30) + '     --------\n');
-    }
-    
+        output.queue(wrap('ACTUAL', 30) + ' EXPECTED\n');
+        output.queue(wrap('------', 30) + ' --------\n');
+    }    
     tuple(actual.pipe(split()), expected.pipe(split()))
         .pipe(output)
         .pipe(process.stdout)
@@ -100,7 +103,7 @@ function compare (actual, expected, opts) {
         equal = equal && eq;
         
         if (opts.long) {
-            this.queue('ACTUAL:   '
+            this.queue('ACTUAL: '
                 + COLORS[eq ? 'PASS' : 'FAIL']
                 + JSON.stringify(pair[0])
                 + COLORS.RESET + '\n'
@@ -113,7 +116,7 @@ function compare (actual, expected, opts) {
             this.queue(
                 COLORS[eq ? 'PASS' : 'FAIL']
                 + wrap(JSON.stringify(pair[0]), 30)
-                + ' ' + (eq ? '   ' : '!==') + ' '
+                + ' ' + (eq ? ' ' : '!==') + ' '
                 + wrap(JSON.stringify(pair[1]), 30)
                 + '\n'
             );

--- a/bin/verify.js
+++ b/bin/verify.js
@@ -53,7 +53,7 @@ module.exports = function (acmd, bcmd, opts) {
         b.on('kill', function () { if (b.kill) b.kill() });
     }
     
-    var c = compare(a.stdout || a, b.stdout || b, opts);
+    var c = compare(opts.a || a.stdout || a, opts.b || b.stdout || b, opts);
     
     if (opts.showStdout) {
         (a.stdout || a).pipe(process.stdout);

--- a/problems/websockets/setup.js
+++ b/problems/websockets/setup.js
@@ -8,9 +8,9 @@ var path = require('path');
 var entry = path.resolve(process.argv[3]);
 
 module.exports = function () {
-    var actual = through()
-    var expected = through().pause()
-    expected.queue('hello\n')
+    var actual = through();
+    var expected = through().pause();
+    expected.queue('hello\n');
     expected.queue(null);
     
     var httpServer = http.createServer(function (req, res) {
@@ -22,8 +22,8 @@ module.exports = function () {
             });
         }
         else {
-            res.setHeader('content-type', 'text/html')
-            return res.end('<script src="/bundle.js"></script>')
+            res.setHeader('content-type', 'text/html');
+            return res.end('<script src="/bundle.js"></script>');
         }
     });
     
@@ -33,12 +33,12 @@ module.exports = function () {
             socket.destroy();
         });
         wsServer.handleUpgrade(req, socket, head, function(conn) {
-            var stream = websocket(conn)
+            var stream = websocket(conn);
             stream.pipe(actual);
         });
     });
     httpServer.listen(8000);
-    
+
     console.log('################################################');
     console.log('#                                              #');
     console.log('# Open http://localhost:8000 to run your code! #');


### PR DESCRIPTION
EDIT2: All fixed! It's still hacky... but now it shouldn't interfere with any of the existing puzzles in stream-adventure anymore. I have it so that it checks if opts.a or opts.b are functions. If they aren't, then my solution is used. With the exception of websockets, all of the puzzles either supply a function or undefined for opts.a and opts.b.

---

EDIT: THIS CHANGE BREAKS THE DUPLEXER PROBLEM. DO NOT MERGE.

I'm working on a less hacky solution. Sorry about that. :(

---

There is a bug in the websockets problem, where the verify script shows a blank string for both the actual and expected results. This means that any solution which connects to the server will be verified, regardless of the information sent to the server. I fix this (for the most part) by providing opts.a and opts.b as additional, possible arguments when the compare() function is called from within /bin/verify.js. It will still pass if extra lines are provided or the \n is left off, but at least it checks for SOMETHING now. In all of the other problems, opts.a and opts.b are falsy (undefined) so for those, verify.js should fall back to the old behavior.
