### PR TITLE
Changing html_stream to use selectAll instead of select

### DIFF
--- a/problems/html_stream/problem.txt
+++ b/problems/html_stream/problem.txt
@@ -10,7 +10,10 @@ With `trumpet` you can create a transform stream from a css selector:
     var tr = trumpet();
     fs.createReadStream('input.html').pipe(tr);
     
-    var stream = tr.select('.beep').createStream();
+    tr.selectAll('.beep', fucntion(elem) {
+      var beep = elem.createStream();
+      beep.pipe(beep);
+    });
 
 Now `stream` outputs all the inner html content at `'.beep'` and the data you
 write to `stream` will appear as the new inner html content.

--- a/problems/html_stream/solution.js
+++ b/problems/html_stream/solution.js
@@ -2,9 +2,16 @@ var trumpet = require('trumpet');
 var through = require('through');
 var tr = trumpet();
 
-var loud = tr.select('.loud').createStream();
-loud.pipe(through(function (buf) {
-    this.queue(buf.toString().toUpperCase());
-})).pipe(loud);
+tr.selectAll('.loud', function (elem) {
+  var loud = elem.createStream();
+  var th = through(function write(data) {
+    this.queue(data.toString().toUpperCase());
+  }, 
+  function end () {
+    this.queue(null);
+  });
+                   
+  loud.pipe(th).pipe(loud);
+});
 
 process.stdin.pipe(tr).pipe(process.stdout);


### PR DESCRIPTION
Changing solution and example to use trumpet's selectAll instead of select, as the problem text says to convert ALL the inner html.
