### PR TITLE
make websockets exercise testable in cloud9

### DIFF
--- a/problems/websockets/index.js
+++ b/problems/websockets/index.js
@@ -57,10 +57,13 @@ function createServer (main) {
             return res.end('<script src="/bundle.js"></script>')
         }
     });
-    server.listen(8099, function () {
+    server.listen(process.env.PORT || 8099, function () {
         console.log('################################################');
         console.log('#                                              #');
-        console.log('# Open http://localhost:8099 to run your code! #');
+        console.log('# Open http://localhost:' + process.env.PORT || 8099 + ' to run your code! #');
+        console.log('# if you are doing this exercise in c9.io,     #');
+        console.log('# Open http://<domain name of your workspace>  #');
+        console.log('# e.g. http://<workspacename>-<c9usernam>.c9.io#');
         console.log('#                                              #');
         console.log('################################################');
         console.log();

--- a/problems/websockets/solution.js
+++ b/problems/websockets/solution.js
@@ -1,5 +1,7 @@
 // Here's the reference solution:
 
   var ws = require('websocket-stream');
-  var stream = ws('ws://localhost:8099');
+  //if you do this exercise in c9.io, stop apache2, and your web socket server
+  //will listen at process.env.PORT, normally is 8080.
+  var wss = ws('ws://' + window.location.hostname + ':' + window.location.port);
   stream.write('hello\n');


### PR DESCRIPTION
In c9.io, there is no easy way to open a local browser. instead c9.io will give your c9 work space a public accessible domain name.  so we make websockets verify code listening on the normal port used by apache2, and we can test the websockets client code from a public ip address.
