### PR TITLE
Match parts of hint

### DIFF
--- a/problems/transform/problem.txt
+++ b/problems/transform/problem.txt
@@ -11,7 +11,7 @@ produce the output data.
 Create a through stream with a `write` and `end` function:
 
     var through = require('through2');
-    var stream = through(write, end);
+    var tr = through(write, end);
 
 The `write` function is called for every buffer of available input:
 


### PR DESCRIPTION
The variable `tr` is not defined anywhere in the scope of the hint. It is less confusing to define the through stream as `tr` to match both the bottom examples and the hint.
