### PR TITLE
html_stream, support for multiple 'loud' tags

### DIFF
--- a/problems/html_stream/expected.html
+++ b/problems/html_stream/expected.html
@@ -7,7 +7,7 @@
       Four score and several years ago, our fathers bought four swiss
       continents, a new vacation, covered in liberty.
       And predicated to the preposition that tall men created a
-      sequel.
+      sequel. <span class="loud">FIRST LOUD TEXT.</span>
     </p>
     
     <p>

--- a/problems/html_stream/input.html
+++ b/problems/html_stream/input.html
@@ -7,7 +7,7 @@
       Four score and several years ago, our fathers bought four swiss
       continents, a new vacation, covered in liberty.
       And predicated to the preposition that tall men created a
-      sequel.
+      sequel. <span class="loud">first loud text.</span>
     </p>
     
     <p>

--- a/problems/html_stream/solution.js
+++ b/problems/html_stream/solution.js
@@ -4,10 +4,12 @@
   var through = require('through2');
   var tr = trumpet();
   
-  var loud = tr.select('.loud').createStream();
-  loud.pipe(through(function (buf, _, next) {
+  tr.selectAll('.loud', function(loud) {
+  	var stream = loud.createStream();
+  	stream.pipe(through(function (buf, _, next) {
       this.push(buf.toString().toUpperCase());
       next();
-  })).pipe(loud);
+  	})).pipe(stream);
+  });
   
   process.stdin.pipe(tr).pipe(process.stdout);

--- a/problems/html_stream/solution.js
+++ b/problems/html_stream/solution.js
@@ -5,11 +5,11 @@
   var tr = trumpet();
   
   tr.selectAll('.loud', function(loud) {
-  	var stream = loud.createStream();
-  	stream.pipe(through(function (buf, _, next) {
+    var stream = loud.createStream();
+    stream.pipe(through(function (buf, _, next) {
       this.push(buf.toString().toUpperCase());
       next();
-  	})).pipe(stream);
+    })).pipe(stream);
   });
   
   process.stdin.pipe(tr).pipe(process.stdout);


### PR DESCRIPTION
Current implementation transforms only first 'loud' element to uppercase, others are ignored.
