### PR TITLE
Remove stream-combiner2 dependency for the duplexer problem

### DIFF
--- a/problems/duplexer/command.js
+++ b/problems/duplexer/command.js
@@ -1,10 +1,8 @@
 var through = require('through2');
 var split = require('split');
-var combine = require('stream-combiner2');
 var offset = Number(process.argv[2]);
 
-var tr = combine(split(), through(write));
-process.stdin.pipe(tr).pipe(process.stdout);
+process.stdin.pipe(split()).pipe(through(write)).pipe(process.stdout);
 
 function write (buf, _, next) {
     var line = buf.toString();


### PR DESCRIPTION
The pipe to stream-combiner2 in the command used in the duplexer problem caused the provided solution to fail. With the pipe, output stopped after the first newline character. The solution runs correctly without the pipe.

Closes #155
