### PR TITLE
fix http_server problem (use full input on every retry)

### DIFF
--- a/problems/http_server/index.js
+++ b/problems/http_server/index.js
@@ -44,9 +44,10 @@ exports.verify = verify({ modeReset: true }, function (args, t) {
             t.equal(body.toString(), expected.join(''));
             ps.kill();
         }));
+        var input_i = 0;
         var iv = setInterval(function () {
-            if (input.length) {
-                hq.write(input.shift());
+            if (input_i < input.length) {
+                hq.write(input[input_i++]);
             }
             else {
                 clearInterval(iv);


### PR DESCRIPTION
My solution for the http_server problem fails almost all the time because of a bug in the stream-adventure codebase's tester that makes it fail to send the first word of input over http most of the time.

This is presumably because of a race condition, and that the retry code doesn't re-send words that tried to send to a past (failed) connection.

My patch fixes the retry code so that it passes all the words on every try.
