### PR TITLE
Update Secretz solution for latest tar. Fixes #202.

### DIFF
--- a/problems/secretz/solution.js
+++ b/problems/secretz/solution.js
@@ -5,14 +5,15 @@
   var zlib = require('zlib');
   var concat = require('concat-stream');
 
-  var parser = tar.Parse();
+  var parser = new tar.Parse();
   parser.on('entry', function (e) {
-      if (e.type !== 'File') return;
-      
-      var h = crypto.createHash('md5', { encoding: 'hex' });
-      e.pipe(h).pipe(concat(function (hash) {
-          console.log(hash + ' ' + e.path);
-      }));
+      if (e.type === 'File') {
+          var h = crypto.createHash('md5', { encoding: 'hex' });
+          e.pipe(h).pipe(concat(function (hash) {
+              console.log(hash + ' ' + e.path);
+          }));
+      }
+      e.resume();
   });
 
   var cipher = process.argv[2];


### PR DESCRIPTION
The current solution for the 'Secretz' adventure fails with the error described in #202. Using the `new` keyword will fix this particular error, but the solution will still fail because of API changes to the `tar` parser events. Per the [documentation](https://github.com/npm/node-tar/blob/master/README.md#class-tarparse), we must now call `e.resume()` so the stream will continue to flow.