### PR TITLE
Fixed Secretz Solution

### DIFF
--- a/test/solutions/secretz.js
+++ b/test/solutions/secretz.js
@@ -5,7 +5,7 @@ var concat = require('concat-stream');
 
 var parser = new tar.Parse();
 parser.on('entry', function (e) {
-    if (e.type !== 'File') resume();
+    if (e.type !== 'File') e.resume();
     
     var h = crypto.createHash('md5', { encoding: 'hex' });
     e.pipe(h).pipe(concat(function (hash) {

--- a/test/solutions/secretz.js
+++ b/test/solutions/secretz.js
@@ -3,9 +3,9 @@ var tar = require('tar');
 var zlib = require('zlib');
 var concat = require('concat-stream');
 
-var parser = tar.Parse();
+var parser = new tar.Parse();
 parser.on('entry', function (e) {
-    if (e.type !== 'File') return;
+    if (e.type !== 'File') resume();
     
     var h = crypto.createHash('md5', { encoding: 'hex' });
     e.pipe(h).pipe(concat(function (hash) {


### PR DESCRIPTION
tar.Parse class has to be invoked with new.
While return at its on method, return was replaced with resume().