### PR TITLE
Update the usage of tar.Parse()

### DIFF
--- a/problems/secretz/problem.txt
+++ b/problems/secretz/problem.txt
@@ -20,7 +20,7 @@ of the file contents from the archive and:
 Using the tar module looks like:
 
     var tar = require('tar');
-    var parser = tar.Parse();
+    var parser = new tar.Parse();
     parser.on('entry', function (e) {
         console.dir(e);
     });


### PR DESCRIPTION
The `tar.Parse()` already updated, and you must put a `new` before it. The [solution was updated](https://github.com/workshopper/stream-adventure/blob/master/problems/secretz/solution.js#L8), but the problem description didn't. It's a little bit misleading.