### PR TITLE
fix crypto.createCipher deprecation warning

### DIFF
--- a/problems/crypt/index.js
+++ b/problems/crypt/index.js
@@ -16,7 +16,9 @@ exports.verify = verify({ modeReset: true }, function (args, t) {
   t.equal(args.length, 1, 'stream-adventure verify YOURFILE.js')
 
   var pw = words[Math.floor(Math.random() * words.length)]
-  var ps = spawn(process.execPath, [args[0], pw])
+  var key = crypto.createHash('md5').update(pw).digest('hex')
+  var iv = crypto.randomBytes(8).toString('hex')
+  var ps = spawn(process.execPath, [args[0], key, iv])
   ps.once('exit', function (code) {
     t.equal(code, 0, 'successful exit code')
   })
@@ -28,7 +30,7 @@ exports.verify = verify({ modeReset: true }, function (args, t) {
     })
   }))
 
-  var enc = crypto.createCipher('aes256', pw)
+  var enc = crypto.createCipheriv('aes256', key, iv)
   if (!enc.pipe) {
     t.fail('Your version of node is too old to play this level. ' +
             'Please upgrade to node >= 0.10.'
@@ -40,9 +42,11 @@ exports.verify = verify({ modeReset: true }, function (args, t) {
 
 exports.run = function (args) {
   var pw = words[Math.floor(Math.random() * words.length)]
-  var ps = spawn(process.execPath, [args[0], pw])
+  var key = crypto.createHash('md5').update(pw).digest('hex')
+  var iv = crypto.randomBytes(8).toString('hex')
+  var ps = spawn(process.execPath, [args[0], key, iv])
   ps.stderr.pipe(process.stderr)
   ps.stdout.pipe(process.stdout)
-  var enc = crypto.createCipher('aes256', pw)
+  var enc = crypto.createCipheriv('aes256', key, iv)
   fs.createReadStream(file).pipe(enc).pipe(ps.stdin)
 }

--- a/problems/crypt/problem.txt
+++ b/problems/crypt/problem.txt
@@ -1,9 +1,9 @@
-Your program will be given a passphrase on `process.argv[2]` and 'aes256'
+Your program will be given a passphrase on `process.argv[2]`, an initialization value on `process.argv[3]` and 'aes256'
 encrypted data will be written to stdin.
 
 Simply decrypt the data and stream the result to process.stdout.
 
-You can use the `crypto.createDecipher()` api from node core to solve this
+You can use the `crypto.createDecipheriv()` api from node core to solve this
 challenge. Here's an example:
 
     var crypto = require('crypto');

--- a/problems/crypt/solution.js
+++ b/problems/crypt/solution.js
@@ -2,5 +2,5 @@
 
 var crypto = require('crypto')
 process.stdin
-  .pipe(crypto.createDecipher('aes256', process.argv[2]))
+  .pipe(crypto.createDecipheriv('aes256', process.argv[2], process.argv[3]))
   .pipe(process.stdout)

--- a/problems/secretz/problem.txt
+++ b/problems/secretz/problem.txt
@@ -3,9 +3,10 @@ challenge, for each file in the tar input, print a hex-encoded md5 hash of the
 file contents followed by a single space followed by the filename, then a
 newline.
 
-You will receive the cipher name as process.argv[2] and the cipher passphrase as
-process.argv[3]. You can pass these arguments directly through to
-`crypto.createDecipher()`.
+You will receive the cipher algorithm name as process.argv[2], the cipher key as
+process.argv[3] and the cipher initialization vector as process.argv[4].
+You can pass these arguments directly through to
+`crypto.createDecipheriv()`.
 
 The built-in zlib library you get when you `require('zlib')` has a
 `zlib.createGunzip()` that returns a stream for gunzipping.

--- a/problems/secretz/solution.js
+++ b/problems/secretz/solution.js
@@ -16,8 +16,9 @@ parser.on('entry', function (e) {
 })
 
 var cipher = process.argv[2]
-var pw = process.argv[3]
+var key = process.argv[3]
+var iv = process.argv[4]
 process.stdin
-  .pipe(crypto.createDecipher(cipher, pw))
+  .pipe(crypto.createDecipheriv(cipher, key, iv))
   .pipe(zlib.createGunzip())
   .pipe(parser)

--- a/test/solutions/crypt.js
+++ b/test/solutions/crypt.js
@@ -1,4 +1,4 @@
 var crypto = require('crypto')
 process.stdin
-  .pipe(crypto.createDecipher('aes256', process.argv[2]))
+  .pipe(crypto.createDecipheriv('aes256', process.argv[2], process.argv[3]))
   .pipe(process.stdout)

--- a/test/solutions/secretz.js
+++ b/test/solutions/secretz.js
@@ -14,8 +14,9 @@ parser.on('entry', function (e) {
 })
 
 var cipher = process.argv[2]
-var pw = process.argv[3]
+var key = process.argv[3]
+var iv = process.argv[4]
 process.stdin
-  .pipe(crypto.createDecipher(cipher, pw))
+  .pipe(crypto.createDecipheriv(cipher, key, iv))
   .pipe(zlib.createGunzip())
   .pipe(parser)


### PR DESCRIPTION
Update problems to use `crypto.createCipheriv` and `crypto.createDecipheriv` instead `crypto.createCipher` and `crypto.createDecipher` that are deprecated

Open this PR for feedback before rebase into master.