### PR TITLE
replace split dependency to split2

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "hyperquest": "^2.1.3",
     "osenv": "^0.1.0",
     "provinces": "^1.11.0",
-    "split": "~1.0.0",
+    "split2": "^3.1.1",
     "stream-combiner": "^0.2.1",
     "tar": "^6.0.1",
     "through2": "^3.0.1",

--- a/problems/combiner/problem.md
+++ b/problems/combiner/problem.md
@@ -61,15 +61,15 @@ front 'end' of the stream, reads the associated JSON, processes the input book
 data by grouping it by genre and produces a gzipped result stream from which 
 the result may be read.
 
-As in the previous LINES adventure, the `split` module is very handy here. You
+As in the previous LINES adventure, the `split2` module is very handy here. You
 can put a split stream directly into the stream-combiner pipeline.
 Note that split can send empty lines too.
 
-If you end up using `split` and `stream-combiner`, make sure to install them
+If you end up using `split2` and `stream-combiner`, make sure to install them
 into the directory where your solution file resides by doing:
 
 ```sh
-$ npm install stream-combiner split
+$ npm install stream-combiner split2
 ```
 
 To verify your solution run:

--- a/problems/combiner/problem.md
+++ b/problems/combiner/problem.md
@@ -62,8 +62,8 @@ data by grouping it by genre and produces a gzipped result stream from which
 the result may be read.
 
 As in the previous LINES adventure, the `split2` module is very handy here. You
-can put a split stream directly into the stream-combiner pipeline.
-Note that split can send empty lines too.
+can put a split2 stream directly into the stream-combiner pipeline.
+Note that split2 can send empty lines too.
 
 If you end up using `split2` and `stream-combiner`, make sure to install them
 into the directory where your solution file resides by doing:

--- a/problems/combiner/solution.js
+++ b/problems/combiner/solution.js
@@ -1,6 +1,6 @@
 const combine = require('stream-combiner')
 const through = require('through2')
-const split = require('split')
+const split2 = require('split2')
 const zlib = require('zlib')
 
 module.exports = function () {
@@ -28,5 +28,5 @@ module.exports = function () {
     next()
   }
 
-  return combine(split(), grouper, zlib.createGzip())
+  return combine(split2(), grouper, zlib.createGzip())
 }

--- a/problems/duplexer/command.js
+++ b/problems/duplexer/command.js
@@ -1,9 +1,9 @@
 const through = require('through2')
-const split = require('split')
+const split2 = require('split2')
 const combine = require('stream-combiner')
 const offset = Number(process.argv[2])
 
-const tr = combine(split(), through(write))
+const tr = combine(split2(), through(write))
 process.stdin.pipe(tr).pipe(process.stdout)
 
 function write (buf, _, next) {

--- a/problems/lines/problem.md
+++ b/problems/lines/problem.md
@@ -41,9 +41,7 @@ $ echo -e 'one\ntwo\nthree' | node split.js
 ```
 
 Your own program could use `split2` in this way, and you should transform the
-input and pipe the output through to `process.stdout`. Keep in mind that,
-if you decide to use this technique, `split2` might be actually needed,
-depending on the versions of the other dependencies.
+input and pipe the output through to `process.stdout`.
 
 You are free to solve the challenge without `split2` module. In this case,
 you would have to add a new line after each line to have a passing match.

--- a/problems/lines/problem.md
+++ b/problems/lines/problem.md
@@ -15,21 +15,21 @@ Your program should output:
     three
     FOUR
 
-Even though it's not obligatory, you can use the `split` module 
+Even though it's not obligatory, you can use the `split2` module 
 to split input by newlines. For example:
 
 ```js
-const split = require('split')
+const split2 = require('split2')
 const through2 = require('through2')
 process.stdin
-  .pipe(split())
+  .pipe(split2())
   .pipe(through2(function (line, _, next) {
       console.dir(line.toString())
       next();
   }))
 ```
 
-`split` will buffer chunks on newlines before you get them. With example
+`split2` will buffer chunks on newlines before you get them. With example
 above, we will get separate events for each line even though all the data
 probably arrives on the same chunk:
 
@@ -40,13 +40,13 @@ $ echo -e 'one\ntwo\nthree' | node split.js
 'three'
 ```
 
-Your own program could use `split` in this way, and you should transform the
+Your own program could use `split2` in this way, and you should transform the
 input and pipe the output through to `process.stdout`. Keep in mind that,
 if you decide to use this technique, `split2` might be actually needed,
 depending on the versions of the other dependencies.
 
-You are free to solve the challenge without `split` module. In this case,
+You are free to solve the challenge without `split2` module. In this case,
 you would have to add a new line after each line to have a passing match.
 
-Make sure to `npm install split through2` in the directory where your solution
+Make sure to `npm install split2 through2` in the directory where your solution
 file lives.

--- a/problems/lines/solution.js
+++ b/problems/lines/solution.js
@@ -1,5 +1,5 @@
 const through = require('through2')
-const split = require('split')
+const split2 = require('split2')
 
 let lineCount = 0
 const tr = through(function (buf, _, next) {
@@ -12,6 +12,6 @@ const tr = through(function (buf, _, next) {
   next()
 })
 process.stdin
-  .pipe(split())
+  .pipe(split2())
   .pipe(tr)
   .pipe(process.stdout)

--- a/test/solutions/combiner.js
+++ b/test/solutions/combiner.js
@@ -1,6 +1,6 @@
 const combine = require('stream-combiner')
 const through = require('through2')
-const split = require('split')
+const split2 = require('split2')
 const zlib = require('zlib')
 
 module.exports = function () {
@@ -28,5 +28,5 @@ module.exports = function () {
     next()
   }
 
-  return combine(split(), grouper, zlib.createGzip())
+  return combine(split2(), grouper, zlib.createGzip())
 }

--- a/test/solutions/lines.js
+++ b/test/solutions/lines.js
@@ -1,8 +1,8 @@
-const split = require('split')
+const split2 = require('split2')
 const through = require('through2')
 
 let count = 0
-process.stdin.pipe(split()).pipe(through(function (line, _, next) {
+process.stdin.pipe(split2()).pipe(through(function (line, _, next) {
   if (count++ % 2) {
     this.push(line.toString().toUpperCase() + '\n')
   } else {


### PR DESCRIPTION
Those files which require split are replaced to split2. The package.json dependencies are also updated.