### PR TITLE
fix(read_it): remove constructor args

### DIFF
--- a/problems/read_it/solution.js
+++ b/problems/read_it/solution.js
@@ -5,6 +5,6 @@ class ReadableStream extends Readable {
   }
 }
 
-const stream = new ReadableStream(process.argv[2])
+const stream = new ReadableStream()
 stream.push(process.argv[2])
 stream.pipe(process.stdout)


### PR DESCRIPTION
There is no need to pass anything to Readable constructor.