### PR TITLE
Clarify write_to_me challenge statement

### DIFF
--- a/problems/write_to_me/problem.md
+++ b/problems/write_to_me/problem.md
@@ -57,4 +57,4 @@ Also you can use the `pipe` method, that we'd learned before.
 ### Challenge
 
 Implement a writable stream that writes in console `writing: ` + the given chunk
-And pipe it to `process.stdin`
+New chunks are sent through stdin.


### PR DESCRIPTION
"pipe it to `process.stdin`"  makes it sound like `.pipe(process.stdin)` but the correct solution is `process.stdin.pipe()`